### PR TITLE
サーヴァント詳細ページのアイテムのリンクがずれる問題の修正

### DIFF
--- a/components/servants/material-list.tsx
+++ b/components/servants/material-list.tsx
@@ -8,14 +8,17 @@ import {
   VStack,
 } from '@chakra-ui/react'
 import React from 'react'
-import type { Materials } from '../../interfaces/atlas-academy'
+import type { Item, Materials } from '../../interfaces/atlas-academy'
 import { toApiItemId } from '../../lib/to-api-item-id'
 import { ItemLink } from '../common/item-link'
 
-export const MaterialList = ({ materials }: { materials: Materials }) => {
-  const items = Object.values(materials).flatMap(({ items }) =>
-    items.map(({ item }) => item)
-  )
+export const MaterialList = ({
+  materials,
+  items,
+}: {
+  materials: Materials
+  items: Item[]
+}) => {
   return (
     <VStack align="stretch" spacing={8}>
       {Object.entries(materials).map(([lv, materials]) => (

--- a/components/servants/servant.tsx
+++ b/components/servants/servant.tsx
@@ -20,7 +20,7 @@ import { useTranslation } from 'react-i18next'
 
 const keys: TargetKey[] = ['ascension', 'skill', 'appendSkill']
 
-export const Page: NextPage<ServantProps> = ({ servant }) => {
+export const Page: NextPage<ServantProps> = ({ servant, items }) => {
   const router = useRouter()
   const { t } = useTranslation(['servants', 'common'])
   if (router.isFallback) {
@@ -51,7 +51,10 @@ export const Page: NextPage<ServantProps> = ({ servant }) => {
         {keys.map((key) => (
           <VStack align="stretch" key={key} spacing={4}>
             <Heading size="lg">{t(key, { ns: 'common' })}</Heading>
-            <MaterialList materials={servant[`${key}Materials`]} />
+            <MaterialList
+              materials={servant[`${key}Materials`]}
+              items={items}
+            />
           </VStack>
         ))}
       </SimpleGrid>

--- a/pages/servants/[id].tsx
+++ b/pages/servants/[id].tsx
@@ -2,9 +2,10 @@ import { GetStaticPaths, GetStaticProps } from 'next'
 import { getNiceServants } from '../../lib/get-nice-servants'
 import { getServants } from '../../lib/get-servants'
 import { Page } from '../../components/servants/servant'
-import { NiceServant } from '../../interfaces/atlas-academy'
+import { Item, NiceServant } from '../../interfaces/atlas-academy'
+import { getItems } from '../../lib/get-items'
 
-export type ServantProps = { servant: NiceServant }
+export type ServantProps = { servant: NiceServant; items: Item[] }
 
 export const getStaticPaths: GetStaticPaths = async ({ locales = ['ja'] }) => {
   const servants = await getServants()
@@ -21,10 +22,13 @@ export const getStaticProps: GetStaticProps<ServantProps> = async ({
   params,
   locale,
 }) => {
-  const servant = await getNiceServants(locale).then((servants) =>
-    servants.find(({ id }) => id.toString() == params?.id)
-  )
-  return servant == null ? { notFound: true } : { props: { servant } }
+  const [servant, items] = await Promise.all([
+    getNiceServants(locale).then((servants) =>
+      servants.find(({ id }) => id.toString() == params?.id)
+    ),
+    getItems(locale),
+  ])
+  return servant == null ? { notFound: true } : { props: { servant, items } }
 }
 
 export default Page


### PR DESCRIPTION
#48 でアイテムIDを`findIndex`で出すようにしたために、サーヴァント詳細ページ（必要素材のアイテムしか取得していない）のアイテムIDがずれるようになってしまったので、全アイテムを渡すように修正