### PR TITLE
Add class of beastEresh

### DIFF
--- a/lib/class-names.ts
+++ b/lib/class-names.ts
@@ -16,6 +16,7 @@ export const classNames: { [locale: string]: { [className: string]: string } } =
       foreigner: 'フォーリナー',
       pretender: 'プリテンダー',
       beast: 'ビースト',
+      beastEresh: 'ビースト(エレシュ)',
     },
     en: {
       saber: 'Saber',
@@ -33,6 +34,7 @@ export const classNames: { [locale: string]: { [className: string]: string } } =
       foreigner: 'Foreigner',
       pretender: 'Pretender',
       beast: 'beast',
+      beastEresh: 'beastEresh',
     },
   }
 


### PR DESCRIPTION
## 概要

いつも利用させております。
エレシュキガル(ビースト)が育成素材計算機に入れられず、困っておりました。

影響範囲の精査ができていない、
ドラコーのビーストとエレシュキガルのビーストを同じにすべき、のような検討は必要かと思いますが、
一旦これで悪影響がなければ、計算に入れることはできるので、ご検討いただければ幸いです。

## 変更内容


<img width="700" alt="image" src="https://github.com/user-attachments/assets/c915f11d-1ae6-453c-861a-abf4623112bb">


<img width="701" alt="image" src="https://github.com/user-attachments/assets/0b76b783-2fa5-44cb-8d25-335c38d92f8d">


<img width="364" alt="image" src="https://github.com/user-attachments/assets/eee6e3d2-e678-4138-8e3e-2dd32b6cc35a">
